### PR TITLE
docs/builder.md: remove BuilderByTarget references

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -37,7 +37,7 @@ Your builder will need a constant for the target it implements. Usually that con
 can just be the ID of the distribution you are implementing, as taken reading `/etc/os-release` file.  
 A builder can implement more than one target at time. For example, the minikube builder is just a vanilla one.
 
-Once you have the constant, you will need to add it to the `BuilderByTarget` map.  
+Once you have the constant, you will need to add it to the [byTarget](https://github.com/falcosecurity/driverkit/blob/master/pkg/driverbuilder/builder/target.go) map. 
 Open your file and you will need to add something like this:
 
 ```go
@@ -48,7 +48,7 @@ type archLinux struct {
 }
 
 func init() {
-	BuilderByTarget[TargetTypeArchLinux] = &archLinux{}
+	byTarget[TargetTypeArchLinux] = &archLinux{}
 }
 ```
 


### PR DESCRIPTION
The 'Target name' subsection is old. `BuilderByTarget` isn't used anymore; it's now `byTarget` in `target.go`. Add a hyperlink for clarity and accessibility.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

/kind documentation

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area pkg

/area docs

**What this PR does / why we need it**:

The commit by @FedeDP seems to have caused this https://github.com/falcosecurity/driverkit/commit/56573f405914c2bb63b77a2bf8f0f3e64c8afde3, but it appears that the documentation hasn't been updated to match the current logic of the builders.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

No

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

No
